### PR TITLE
Parsing null fields with `jq`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 _build
 .cache
 *.so
+pip-wheel-metadata/
 
 # Unit test / coverage reports
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # snucovery ChangeLog
 
+## 1.0.3 2019-08-16
+
+* Allow `jq` to properly parse fields that contain `null` values.
+
 ## 1.0.0 2019-01-10
 
 * Initial Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snucovery"
-version = "0.1.1"
+version = "0.1.3"
 description = "Command Line utility to collect Aws Asset Data and export to Excel Stylesheets"
 authors = ["Johnny Martin <johnny.martin@tylertech.com>"]
 

--- a/snucovery/aws.py
+++ b/snucovery/aws.py
@@ -41,17 +41,17 @@ class AwsServices:
 
         self.service_mappings = {
             'ec2': {
-                'describe_instances': ".Reservations[].Instances[] | {Name: (.Tags[]|select(.Key==\"Name\")|.Value), InstanceId, InstanceType, Region: .Placement.AvailabilityZone, LaunchTime, PrivateDnsName, PrivateIpAddresses: [.NetworkInterfaces[].PrivateIpAddresses[].PrivateIpAddress], PublicIpAddress}",
-                'describe_vpcs': ".Vpcs[] | {Name: (.Tags[]|select(.Key==\"Name\")|.Value), VpcId, CidrBlock}"
+                'describe_instances': ".Reservations[].Instances[]? | {Name: (.Tags[]?|select(.Key==\"Name\")|.Value), InstanceId, InstanceType, Region: .Placement.AvailabilityZone, LaunchTime, PrivateDnsName, PrivateIpAddresses: [.NetworkInterfaces[].PrivateIpAddresses[].PrivateIpAddress], PublicIpAddress}",
+                'describe_vpcs': ".Vpcs[]? | {Name: (.Tags[]|select(.Key==\"Name\")|.Value), VpcId, CidrBlock}"
             },
             'elb': {
-                'describe_load_balancers': ".LoadBalancerDescriptions[] | {LoadBalancerName, DNSName}"
+                'describe_load_balancers': ".LoadBalancerDescriptions[]? | {LoadBalancerName, DNSName}"
             },
             'rds': {
-                'describe_db_instances': ".DBInstances[] | {DBName, AvailabilityZone, DBInstanceIdentifier, DBInstanceClass, Engine}"
+                'describe_db_instances': ".DBInstances[]? | {DBName, AvailabilityZone, DBInstanceIdentifier, DBInstanceClass, Engine}"
             },
             'elasticache': {
-                'describe_cache_clusters': ".CacheClusters[] | {CacheClusterId, CacheNodeType, Engine, PreferredAvailabilityZone}"
+                'describe_cache_clusters': ".CacheClusters[]? | {CacheClusterId, CacheNodeType, Engine, PreferredAvailabilityZone}"
             }
         }
 


### PR DESCRIPTION
### Description

When AWS returns a the associated metadata, it will fail to parse with
`jq` when a field contains a `null` value.

```bash
Traceback (most recent call last):
  File "snucovery/__init__.py", line 44, in <module>
    main()
  File "snucovery/__init__.py", line 33, in main
    filtered_items = pyjq.all(jq_filter, items[service][service_attr])
  File "/Users/john.martin/.socrata/snucovery/.venv/lib/python3.7/site-packages/pyjq.py", line 49, in all
    return compile(script, vars, library_paths).all(_get_value(value, url, opener))
  File "_pyjq.pyx", line 209, in _pyjq.Script.all (_pyjq.c:2561)
_pyjq.ScriptRuntimeError: Cannot iterate over null (null)
```

Luckily, `jq` has the ability to to do some validation against the
dataset so that we can handle the null fields with `jq`.

- [x] Reviewed and Accepted [contribution guidelines](CONTRIBUTING.md)
- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
